### PR TITLE
utf8-safe string conversion

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -36,9 +36,12 @@ namespace {
 
         virtual void Execute() {
 #ifdef _WIN32
-            std::wstring swDomain = std::wstring(domain.begin(), domain.end());
-            std::wstring swUser = std::wstring(user.begin(), user.end());
-            std::wstring swPassword = std::wstring(password.begin(), password.end());
+            //std::wstring swDomain = std::wstring(domain.begin(), domain.end());
+            //std::wstring swUser = std::wstring(user.begin(), user.end());
+            //std::wstring swPassword = std::wstring(password.begin(), password.end());
+            std::wstring swDomain = ConvertUtf8ToWide(domain);
+            std::wstring swUser = ConvertUtf8ToWide(user);
+            std::wstring swPassword = ConvertUtf8ToWide(password);
             LPCTSTR lpDomain = swDomain.c_str();
             LPCTSTR lpUser = swUser.c_str();
             LPCTSTR lpPass = swPassword.c_str();
@@ -106,6 +109,12 @@ namespace {
         std::string password;
         bool success;
         bool administrator;
+        std::wstring ConvertUtf8ToWide(const std::string& str) {
+            int count = MultiByteToWideChar(CP_UTF8, 0, str.c_str(), str.length(), NULL, 0);
+            std::wstring wstr(count, 0);
+            MultiByteToWideChar(CP_UTF8, 0, str.c_str(), str.length(), &wstr[0], count);
+            return wstr;
+        }
     };
 
     NAN_METHOD(checkUserPassword) {


### PR DESCRIPTION
Fixes the authentication failures when the password contains characters that are not part of the [Basic-Latin Unicode-block](https://en.wikipedia.org/wiki/Basic_Latin_(Unicode_block)) (e.g. German umlauts äöü, French accents éèàù etc.)